### PR TITLE
Removed a workaround needed to make Extension:Math work in MW <1.29

### DIFF
--- a/CrossReference.class.php
+++ b/CrossReference.class.php
@@ -380,14 +380,7 @@ class ExtCrossReference
             $this->lookup[$id]['caption'] = $defaultCaption;
             $this->lookup[$id]['group'] = $group;
             // Expand text
-            // Normally, the following code would have been used:
-            //~ $innerHtml = $parser->recursiveTagParse(trim($text), $frame);
-            // ... However, as per MediaWiki 1.28, it doesn't work as
-            // expected (see https://www.mediawiki.org/wiki/QINU_fix)
-            // because a bug in MediaWiki's parser. The following
-            // workaround have to be used instead (only the following
-            // line):
-            $innerHtml = $wgOut->parseInline(trim($text));
+            $innerHtml = $parser->recursiveTagParse(trim($text), $frame);
             $out = $innerHtml;
             // Build label
             if (isset($argv['showNumber']) || isset($argv['shownumber'])) {
@@ -400,9 +393,6 @@ class ExtCrossReference
                     "</div>"
                 ));
             }
-            // ... The following line is also a part of the workaround
-            // mentioned above:
-            $out = implode(array("<p>", $out,"</p>"));
             if (isset($submatcher)) {
                 $submatcher->clear();
                 $submatcher = null;


### PR DESCRIPTION
I remove my own dirty workaround needed to make Extension:Math work. I do it for two reasons:

1. In favor of switching back to the normal wikitext rendering to make Extension:SimpleMathJax work in MW 1.28
2. The bug in MediaWiki parser that made this workaround necessary seem to be fixed in MW 1.29.

This change will likely break the compatibility with MW prior to 1.28, though. Unfortunately, because the original author has explicitly expressed that he does not want to support MW newer than 1.15, this may become an unresolvable collaboration problem.