### PR TITLE
Fix "PHP Warning:  Parameter 2 to ExtCrossReference::parserAfterTidy expected to be a reference, value

### DIFF
--- a/CrossReference.class.php
+++ b/CrossReference.class.php
@@ -189,7 +189,7 @@ class ExtCrossReference
 
     /** Invoked at the last stage of the p  arsing process.
       */
-    public function parserAfterTidy( &$parser, &$text )
+    public function parserAfterTidy( $parser, &$text )
     {
         $text = preg_replace("/&(amp;)?column;/s", ':', $text);
         // Put back captions


### PR DESCRIPTION
Fixes compatibility with mediawiki 1.35