### PR TITLE
Fix call-by-reference issue introduced with PHP 5.4.0

### DIFF
--- a/CrossReference.php
+++ b/CrossReference.php
@@ -89,6 +89,16 @@ class CrossReference_HookStub
 		return true;
 	}
 
+	/** Handle parserAfterTidy callback while allowing $txt to be passed by reference */
+	public function parserAfterTidy( $parser, &$txt )
+	{
+		if ( is_null( $this->realObj ) ) {
+			$this->realObj = new ExtCrossReference;
+			$this->realObj->clearState( $parser );
+		}
+		return $this->realObj->parserAfterTidy( $parser, $txt);
+	}
+
 	/** Pass through function call */
 	public function __call( $name, $args )
 	{


### PR DESCRIPTION
This fixes the issue https://github.com/staspika/mediawiki-crossreference/issues/14, i.e., the warning "Parameter 1 to ExtCrossReference::parserAfterTidy() expected to be a reference [...]" and the extension not correctly inserting the cross-references into the page. This issue is actually caused by PHP which handles things around passing function variables differently since PHP 5.4.0 (see also https://www.php.net/releases/5_4_0.php regarding allow_call_time_pass_reference, and https://wiki.php.net/rfc/calltimebyref).  Regarding the code change: The "parserAfterTidy" callback, which is the only callback used by the CrossReference extension that requires a call-by-reference variable in order to return modified text, was handled by the __call() method (which, in turn is called through the PHP function call_user_func_array()). This is what was not working anymore and is fixed by implementing the "parserAfterTidy" callback function explicitly and with the correct function parameter declarations for passing on a reference rather than a value.  The fix should be back-compatible with older PHP versions, but I verified it with PHP 7.4.30 (and MediaWiki 1.35.7).